### PR TITLE
Distributed query

### DIFF
--- a/PeerTalk/src/Routing/DhtMessages.cs
+++ b/PeerTalk/src/Routing/DhtMessages.cs
@@ -29,13 +29,39 @@ namespace PeerTalk.Routing
         public string TimeReceived { get; set; }
     }
 
-    enum MessageType
+    /// <summary>
+    ///   The type of DHT/KAD message.
+    /// </summary>
+    public enum MessageType
     {
+        /// <summary>
+        ///   Put a value.
+        /// </summary>
         PutValue = 0,
+
+        /// <summary>
+        ///   Get a value.
+        /// </summary>
         GetValue = 1,
+
+        /// <summary>
+        ///   Indicate that a peer can provide something.
+        /// </summary>
         AddProvider = 2,
+
+        /// <summary>
+        ///   Get the providers for something.
+        /// </summary>
         GetProviders = 3,
+
+        /// <summary>
+        ///   Find a peer.
+        /// </summary>
         FindNode = 4,
+
+        /// <summary>
+        ///   NYI
+        /// </summary>
         Ping = 5
     }
 

--- a/PeerTalk/src/Routing/DistributedQuery.cs
+++ b/PeerTalk/src/Routing/DistributedQuery.cs
@@ -1,0 +1,198 @@
+﻿using Common.Logging;
+using Ipfs;
+using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PeerTalk.Routing
+{
+    /// <summary>
+    ///   A query that is sent to multiple peers.
+    /// </summary>
+    /// <typeparam name="T">
+    ///  The type of answer returned by a peer.
+    /// </typeparam>
+    public class DistributedQuery<T> where T : class
+    {
+        static ILog log = LogManager.GetLogger("PeerTalk.Routing.DistributedQuery");
+        static int nextQueryId = 1;
+
+        CancellationTokenSource runningQuery;
+        List<Peer> visited = new List<Peer>();
+        DhtMessage queryMessage;
+
+        /// <summary>
+        ///   Raised when an answer is obtained.
+        /// </summary>
+        public event EventHandler<T> AnswerObtained;
+
+        /// <summary>
+        ///   The unique identifier of the query.
+        /// </summary>
+        public int Id { get; } = nextQueryId++;
+
+        /// <summary>
+        ///   The received answers for the query.
+        /// </summary>
+        public List<T> Answers { get; } = new List<T>();
+
+        /// <summary>
+        ///   The number of answers needed.
+        /// </summary>
+        /// <remarks>
+        ///   When the numbers <see cref="Answers"/> recaches this limit
+        ///   the <see cref="Run">running query</see> will stop.
+        /// </remarks>
+        public int AnswersNeeded { get; set; } = 1;
+
+        /// <summary>
+        ///   The maximum number of concurrent queries to perform.
+        /// </summary>
+        public int ConcurrencyLevel { get; set; } = 3;
+
+        /// <summary>
+        ///   The distributed hash table.
+        /// </summary>
+        public Dht1 Dht { get; set; }
+
+        /// <summary>
+        ///   The type of query to perform.
+        /// </summary>
+        public MessageType QueryType { get; set; }
+
+        /// <summary>
+        ///   The key to find.
+        /// </summary>
+        public MultiHash QueryKey { get; set; }
+
+        /// <summary>
+        ///   Starts the distributed query.
+        /// </summary>
+        /// <param name="cancel">
+        ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
+        /// </param>
+        /// <returns>
+        ///   A task that represents the asynchronous operation.
+        /// </returns>
+        public async Task Run(CancellationToken cancel)
+        {
+            log.Debug($"Q{Id} run {QueryType} {QueryKey}");
+
+            runningQuery = CancellationTokenSource.CreateLinkedTokenSource(cancel);
+            queryMessage = new DhtMessage
+            {
+                Type = QueryType,
+                Key = QueryKey?.ToArray(),
+            };
+
+            var tasks = Enumerable
+                .Range(1, ConcurrencyLevel)
+                .Select(i => { var id = i; return Ask(id); });
+            await Task.WhenAll(tasks);
+            log.Debug($"Q{Id} found {Answers.Count} answers, visited {visited.Count} peers");
+
+            cancel.ThrowIfCancellationRequested();
+        }
+
+        /// <summary>
+        ///   Ask the next peer the question.
+        /// </summary>
+        async Task Ask(int taskId)
+        {
+            int pass = 0;
+            while (!runningQuery.IsCancellationRequested)
+            {
+                ++pass;
+
+                // Get the nearest peer that has not been visited.
+                var peer = Dht.RoutingTable
+                    .NearestPeers(QueryKey)
+                    .Where(p => !visited.Contains(p))
+                    .FirstOrDefault();
+                if (peer == null)
+                    return;
+                visited.Add(peer);
+
+                // Ask the nearest peer.
+                log.Debug($"Q{Id}.{taskId}.{pass} ask {peer}");
+                try
+                {
+                    using (var stream = await Dht.Swarm.DialAsync(peer, Dht.ToString(), runningQuery.Token))
+                    {
+                        // Send the KAD query and get a response.
+                        ProtoBuf.Serializer.SerializeWithLengthPrefix(stream, queryMessage, PrefixStyle.Base128);
+                        await stream.FlushAsync(runningQuery.Token);
+                        var response = await ProtoBufHelper.ReadMessageAsync<DhtMessage>(stream, runningQuery.Token);
+
+                        // Process answer
+                        ProcessProviders(response.ProviderPeers);
+                        ProcessCloserPeers(response.CloserPeers);
+                    }
+                }
+                catch (Exception e)
+                {
+                    log.Warn($"Q{Id}.{taskId}.{pass} ask failed '{e.Message}'");
+                    // eat it
+                }
+            }
+        }
+
+        void ProcessProviders(DhtPeerMessage[] providers)
+        {
+            if (providers == null)
+                return;
+
+            foreach (var provider in providers)
+            {
+                if (provider.TryToPeer(out Peer p))
+                {
+                    p = Dht.Swarm.RegisterPeer(p);
+                    if (QueryType == MessageType.GetProviders)
+                    {
+                        // Only unique answers
+                        var answer = p as T;
+                        if (!Answers.Contains(answer))
+                        {
+                            AddAnswer(answer);
+                        }
+                    }
+                }
+            }
+        }
+
+        void ProcessCloserPeers(DhtPeerMessage[] closerPeers)
+        {
+            if (closerPeers == null)
+                return;
+            foreach (var closer in closerPeers)
+            {
+                if (closer.TryToPeer(out Peer p))
+                {
+                    p = Dht.Swarm.RegisterPeer(p);
+                    if (QueryType == MessageType.FindNode && QueryKey == p.Id)
+                    {
+                        AddAnswer(p as T);
+                    }
+                }
+            }
+        }
+
+        void AddAnswer(T answer)
+        {
+            if (answer == null)
+                return;
+
+            Answers.Add(answer);
+            if (Answers.Count >= AnswersNeeded && !runningQuery.IsCancellationRequested)
+            {
+                runningQuery.Cancel(false);
+            }
+
+            AnswerObtained?.Invoke(this, answer);
+        }
+    }
+}

--- a/PeerTalk/src/Transports/Tcp.cs
+++ b/PeerTalk/src/Transports/Tcp.cs
@@ -60,7 +60,7 @@ namespace PeerTalk.Transports
             TimeSpan latency = MinReadTimeout; // keep compiler happy
             try
             {
-                log.Debug("connecting to " + address);
+                log.Trace("connecting to " + address);
                 var start = DateTime.Now;
 
                 // Handle cancellation of the connect attempt by disposing
@@ -71,7 +71,7 @@ namespace PeerTalk.Transports
                 };
 
                 latency = DateTime.Now - start;
-                log.Debug($"connected to {address} in {latency.TotalMilliseconds} ms");
+                log.Trace($"connected to {address} in {latency.TotalMilliseconds} ms");
             }
             catch (Exception) when (cancel.IsCancellationRequested)
             {
@@ -84,7 +84,7 @@ namespace PeerTalk.Transports
             }
             if (cancel.IsCancellationRequested)
             {
-                log.Debug("cancel " + address);
+                log.Trace("cancel " + address);
                 socket?.Dispose();
                 cancel.ThrowIfCancellationRequested();
             }
@@ -104,7 +104,7 @@ namespace PeerTalk.Transports
 
             if (cancel.IsCancellationRequested)
             {
-                log.Debug("cancel " + address);
+                log.Trace("cancel " + address);
                 stream.Dispose();
                 cancel.ThrowIfCancellationRequested();
             }

--- a/PeerTalk/test/Routing/DistributedQueryTests.cs
+++ b/PeerTalk/test/Routing/DistributedQueryTests.cs
@@ -1,0 +1,34 @@
+﻿using Ipfs;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PeerTalk.Routing
+{
+    
+    [TestClass]
+    public class DistributedQueryTest
+    {
+        [TestMethod]
+        public void Cancelling()
+        {
+            var dquery = new DistributedQuery<Peer>();
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            ExceptionAssert.Throws<TaskCanceledException>(() =>
+            {
+                dquery.Run(cts.Token).Wait();
+            });
+        }
+
+        [TestMethod]
+        public void UniqueId()
+        {
+            var q1 = new DistributedQuery<Peer>();
+            var q2 = new DistributedQuery<Peer>();
+            Assert.AreNotEqual(q1.Id, q2.Id);
+        }
+    }
+}

--- a/src/CoreApi/BlockApi.cs
+++ b/src/CoreApi/BlockApi.cs
@@ -127,23 +127,23 @@ namespace Ipfs.Engine.CoreApi
                     id: id,
                     limit: 20, // TODO: remove this
                     cancel: queryCancel.Token,
-                    action: ProviderFound
+                    action: (peer) => { var __ = ProviderFound(peer, queryCancel.Token); }
                 );
 
                 var got = await bitswapGet;
 
-                queryCancel.Cancel(); // stop the network query.
+                queryCancel.Cancel(false); // stop the network query.
                 return got;
             }
         }
 
-        async void ProviderFound(Peer peer)
+        async Task ProviderFound(Peer peer, CancellationToken cancel)
         {
             log.Debug($"Connecting to provider {peer.Id}");
             var swarm = await ipfs.SwarmService;
             try
             {
-                await swarm.ConnectAsync(peer);
+                await swarm.ConnectAsync(peer, cancel);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Refactor the query logic into a `DistributedQuery`.  Both `FindPeerAsync` and `FindProvidersAsync` will use it.  Hopefully it helps #53  so that `FindPeerAsync` will search for more than 3 peers when needed.

It also improves `FindProvidersAsync` by not waiting for 3 searches to finish, before starting another 3 tasks.
