### PR TITLE
Use a copy of the passphrase in Constructor, dispose of it when diposing the instance

### DIFF
--- a/src/IpfsEngine.cs
+++ b/src/IpfsEngine.cs
@@ -66,7 +66,7 @@ namespace Ipfs.Engine
         /// </param>
         public IpfsEngine(SecureString passphrase)
         {
-            this.passphrase = passphrase;
+            this.passphrase = passphrase.Copy();
             Init();
         }
 
@@ -430,6 +430,7 @@ namespace Ipfs.Engine
         /// </remarks>
         public void Dispose()
         {
+            passphrase?.Dispose();
             StopAsync().Wait();
         }
 


### PR DESCRIPTION
Hi Richard, just a small suggestion / PR for your engine :)
I think it is better if you take a copy of the SecureString in the constructor of the IpfsEngine as you might not know when the user is going to dispose of that SecureString. I would tend to use that password inside of a using() statement that calls the constructor. However, if I dispose of it so quickly all further will struggle with the disposed object.

Hope this helps 😃 