### PR TITLE
Interface for concrete type IpfsEngine

### DIFF
--- a/src/IIpfsEngine.cs
+++ b/src/IIpfsEngine.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Ipfs.CoreApi;
+using Ipfs.Engine.Cryptography;
+using Nito.AsyncEx;
+using PeerTalk;
+
+namespace Ipfs.Engine
+{
+    /// <summary>
+    ///   Offers an abstraction of the IpfsEngine class for consumers of the library.
+    /// </summary>
+    public interface IIpfsEngine : ICoreApi, IService, IDisposable
+    {
+        /// <summary>
+        ///   The configuration options.
+        /// </summary>
+        IpfsEngineOptions Options { get; set; }
+
+        /// <inheritdoc />
+        IBitswapApi Bitswap { get; }
+
+        /// <inheritdoc />
+        IBlockApi Block { get; }
+
+        /// <inheritdoc />
+        IBootstrapApi Bootstrap { get; }
+
+        /// <inheritdoc />
+        IConfigApi Config { get; }
+
+        /// <inheritdoc />
+        IDagApi Dag { get; }
+
+        /// <inheritdoc />
+        IDhtApi Dht { get; }
+
+        /// <inheritdoc />
+        IDnsApi Dns { get; }
+
+        /// <inheritdoc />
+        IFileSystemApi FileSystem { get; }
+
+        /// <inheritdoc />
+        IGenericApi Generic { get; }
+
+        /// <inheritdoc />
+        IKeyApi Key { get; }
+
+        /// <inheritdoc />
+        INameApi Name { get; }
+
+        /// <inheritdoc />
+        IObjectApi Object { get; }
+
+        /// <inheritdoc />
+        IPinApi Pin { get; }
+
+        /// <inheritdoc />
+        IPubSubApi PubSub { get; }
+
+        /// <inheritdoc />
+        ISwarmApi Swarm { get; }
+
+        /// <inheritdoc />
+        IStatsApi Stats { get; }
+
+        /// <summary>
+        ///   Provides access to the local peer.
+        /// </summary>
+        /// <returns>
+        ///   A task that represents the asynchronous operation. The task's result is
+        ///   a <see cref="Peer"/>.
+        /// </returns>
+        AsyncLazy<Peer> LocalPeer { get; }
+
+        /// <summary>
+        ///   Manages communication with other peers.
+        /// </summary>
+        AsyncLazy<Swarm> SwarmService { get; }
+
+        /// <summary>
+        ///   Exchange blocks with other peers.
+        /// </summary>
+        AsyncLazy<BlockExchange.Bitswap> BitswapService { get; }
+
+        /// <summary>
+        ///   Finds information with a distributed hash table.
+        /// </summary>
+        AsyncLazy<PeerTalk.Routing.Dht1> DhtService { get; }
+
+        /// <summary>
+        ///   Provides access to the <see cref="KeyChain"/>.
+        /// </summary>
+        /// <param name="cancel">
+        ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
+        /// </param>
+        /// <returns>
+        ///   A task that represents the asynchronous operation. The task's result is
+        ///   the <see cref="keyChain"/>.
+        /// </returns>
+        Task<KeyChain> KeyChain(CancellationToken cancel = default(CancellationToken));
+
+        /// <summary>
+        ///   Resolve an "IPFS path" to a content ID.
+        /// </summary>
+        /// <param name="path">
+        ///   A IPFS path, such as "Qm...", "Qm.../a/b/c" or "/ipfs/QM..."
+        /// </param>
+        /// <param name="cancel">
+        ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
+        /// </param>
+        /// <returns>
+        ///   The content ID of <paramref name="path"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   The <paramref name="path"/> cannot be resolved.
+        /// </exception>
+        Task<Cid> ResolveIpfsPathToCidAsync (string path, CancellationToken cancel = default(CancellationToken));
+
+        /// <summary>
+        ///   Starts the network services.
+        /// </summary>
+        /// <returns>
+        ///   A task that represents the asynchronous operation.
+        /// </returns>
+        /// <remarks>
+        ///   Starts the various IPFS and PeerTalk network services.  This should
+        ///   be called after any configuration changes.
+        /// </remarks>
+        /// <exception cref="Exception">
+        ///   When the engine is already started.
+        /// </exception>
+        Task StartAsync();
+
+        /// <summary>
+        ///   Stops the running services.
+        /// </summary>
+        /// <returns>
+        ///   A task that represents the asynchronous operation.
+        /// </returns>
+        /// <remarks>
+        ///   Multiple calls are okay.
+        /// </remarks>
+        Task StopAsync();
+
+        /// <summary>
+        ///   Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <remarks>
+        ///   Waits for <see cref="StopAsync"/> to complete.
+        /// </remarks>
+        void Dispose();
+    }
+}

--- a/src/IpfsEngine.cs
+++ b/src/IpfsEngine.cs
@@ -2,9 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
-using System.IO;
 using System.Threading.Tasks;
 using System.Threading;
 using Ipfs.CoreApi;
@@ -28,7 +25,7 @@ namespace Ipfs.Engine
     ///   The engine should be used as a shared object in your program. It is thread safe (re-entrant) and conserves 
     ///   resources when only one instance is used.
     /// </remarks>
-    public partial class IpfsEngine : ICoreApi, IService, IDisposable
+    public partial class IpfsEngine : IIpfsEngine
     {
         static ILog log = LogManager.GetLogger(typeof(IpfsEngine));
 
@@ -197,16 +194,7 @@ namespace Ipfs.Engine
         /// <inheritdoc />
         public IStatsApi Stats { get; private set; }
 
-        /// <summary>
-        ///   Provides access to the <see cref="KeyChain"/>.
-        /// </summary>
-        /// <param name="cancel">
-        ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
-        /// </param>
-        /// <returns>
-        ///   A task that represents the asynchronous operation. The task's result is
-        ///   the <see cref="keyChain"/>.
-        /// </returns>
+        /// <inheritdoc />
         public async Task<KeyChain> KeyChain(CancellationToken cancel = default(CancellationToken))
         {
             if (keyChain == null)
@@ -234,49 +222,17 @@ namespace Ipfs.Engine
             return keyChain;
         }
 
-        /// <summary>
-        ///   Provides access to the local peer.
-        /// </summary>
-        /// <returns>
-        ///   A task that represents the asynchronous operation. The task's result is
-        ///   a <see cref="Peer"/>.
-        /// </returns>
+        /// <inheritdoc />
         public AsyncLazy<Peer> LocalPeer { get; private set; }
 
-        /// <summary>
-        ///   Resolve an "IPFS path" to a content ID.
-        /// </summary>
-        /// <param name="path">
-        ///   A IPFS path, such as "Qm...", "Qm.../a/b/c" or "/ipfs/QM..."
-        /// </param>
-        /// <param name="cancel">
-        ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
-        /// </param>
-        /// <returns>
-        ///   The content ID of <paramref name="path"/>.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///   The <paramref name="path"/> cannot be resolved.
-        /// </exception>
+        /// <inheritdoc />
         public async Task<Cid> ResolveIpfsPathToCidAsync (string path, CancellationToken cancel = default(CancellationToken))
         {
             var r = await Generic.ResolveAsync(path, true, cancel);
             return Cid.Decode(r.Remove(0, 6));  // strip '/ipfs/'.
         }
 
-        /// <summary>
-        ///   Starts the network services.
-        /// </summary>
-        /// <returns>
-        ///   A task that represents the asynchronous operation.
-        /// </returns>
-        /// <remarks>
-        ///   Starts the various IPFS and PeerTalk network services.  This should
-        ///   be called after any configuration changes.
-        /// </remarks>
-        /// <exception cref="Exception">
-        ///   When the engine is already started.
-        /// </exception>
+        /// <inheritdoc cref="IIpfsEngine"/>
         public async Task StartAsync()
         {
             if (stopTasks.Count > 0)
@@ -391,15 +347,7 @@ namespace Ipfs.Engine
             log.Debug("started");
         }
 
-        /// <summary>
-        ///   Stops the running services.
-        /// </summary>
-        /// <returns>
-        ///   A task that represents the asynchronous operation.
-        /// </returns>
-        /// <remarks>
-        ///   Multiple calls are okay.
-        /// </remarks>
+        /// <inheritdoc cref="IIpfsEngine"/>
         public async Task StopAsync()
         {
             log.Debug("stopping");
@@ -422,30 +370,19 @@ namespace Ipfs.Engine
             log.Debug("stopped");
         }
 
-        /// <summary>
-        ///   Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        /// <remarks>
-        ///   Waits for <see cref="StopAsync"/> to complete.
-        /// </remarks>
+        /// <inheritdoc cref="IIpfsEngine"/>
         public void Dispose()
         {
             StopAsync().Wait();
         }
 
-        /// <summary>
-        ///   Manages communication with other peers.
-        /// </summary>
+        /// <inheritdoc />
         public AsyncLazy<Swarm> SwarmService { get; private set; }
 
-        /// <summary>
-        ///   Exchange blocks with other peers.
-        /// </summary>
+        /// <inheritdoc />
         public AsyncLazy<BlockExchange.Bitswap> BitswapService { get; private set; }
 
-        /// <summary>
-        ///   Finds information with a distributed hash table.
-        /// </summary>
+        /// <inheritdoc />
         public AsyncLazy<PeerTalk.Routing.Dht1> DhtService { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
Hello again Richard, another PR / Suggestion:
Here we just declare an interface for the IpfsEngine concrete type. This allows users of the library to mock / substitute the engine in their unit tests 🐱‍💻, I hope you'll think it is worth offering.
I have not had time to go through the codebase and replace the usages of IpfsEngine with usages of IIpfsEngine wherever it made sense, but that is something I don't mind doing if you are willing to take this interface in 👍 