### PR TITLE
$IPFS_PASS 

### DIFF
--- a/doc/articles/envvars.md
+++ b/doc/articles/envvars.md
@@ -8,3 +8,4 @@ are used to control the behaviour of the library
 | HOME | The user's home directory |
 | HOMEPATH | same as `HOME` |
 | IPFS_PATH | The folder of the IPFS [repository](repository.md) |
+| IPFS_PASS | Contains the passphrase for the [key chain](key.md) |

--- a/src/IpfsEngine.cs
+++ b/src/IpfsEngine.cs
@@ -38,6 +38,27 @@ namespace Ipfs.Engine
 
         /// <summary>
         ///   Creates a new instance of the <see cref="IpfsEngine"/> class
+        ///   with the IPFS_PASS environment variable.
+        /// </summary>
+        /// <remarks>
+        ///   Th passphrase must be in the IPFS_PASS environment variable.
+        /// </remarks>
+        public IpfsEngine()
+        {
+            var s = Environment.GetEnvironmentVariable("IPFS_PASS");
+            if (s == null)
+                throw new Exception("The IPFS_PASS environement variable is missing.");
+
+            passphrase = new SecureString();
+            foreach (var c in s)
+            {
+                this.passphrase.AppendChar(c);
+            }
+            Init();
+        }
+
+        /// <summary>
+        ///   Creates a new instance of the <see cref="IpfsEngine"/> class
         ///   with the specified passphrase.
         /// </summary>
         /// <param name="passphrase">
@@ -64,6 +85,9 @@ namespace Ipfs.Engine
         /// <param name="passphrase">
         ///   The password used to access the keychain.
         /// </param>
+        /// <remarks>
+        ///  A copy of the <paramref name="passphrase"/> is made.
+        /// </remarks>
         public IpfsEngine(SecureString passphrase)
         {
             this.passphrase = passphrase.Copy();

--- a/test/IpfsEngineTest.cs
+++ b/test/IpfsEngineTest.cs
@@ -36,6 +36,27 @@ namespace Ipfs.Engine
         }
 
         [TestMethod]
+        public async Task IpfsPass_Passphrase()
+        {
+            var secret = "this is not a secure pass phrase";
+            var ipfs = new IpfsEngine(secret.ToCharArray());
+            ipfs.Options = TestFixture.Ipfs.Options;
+            await ipfs.KeyChain();
+
+            Environment.SetEnvironmentVariable("IPFS_PASS", secret);
+            try
+            {
+                ipfs = new IpfsEngine();
+                ipfs.Options = TestFixture.Ipfs.Options;
+                await ipfs.KeyChain();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("IPFS_PASS", null);
+            }
+        }
+
+        [TestMethod]
         public async Task Wrong_Passphrase()
         {
             var ipfs1 = TestFixture.Ipfs;
@@ -49,6 +70,13 @@ namespace Ipfs.Engine
             {
                 var _ = ipfs2.KeyChain().Result;
             });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(Exception))]
+        public void IpfsPass_Missing()
+        {
+            var _ = new IpfsEngine();
         }
 
         [TestMethod]


### PR DESCRIPTION
`IPFS_PASS `environment variable holds the passphrase when `new IpfsEngine()` is used.  Closes #28 