### PR TITLE
fix(KeyChain): short public IDs #96

### DIFF
--- a/src/Cryptography/KeyChain.cs
+++ b/src/Cryptography/KeyChain.cs
@@ -415,8 +415,15 @@ namespace Ipfs.Engine.Cryptography
             using (var ms = new MemoryStream())
             {
                 ProtoBuf.Serializer.Serialize(ms, publicKey);
+
+                // If the length of the serialized bytes <= 42, then we compute the "identity" multihash of 
+                // the serialized bytes. The idea here is that if the serialized byte array 
+                // is short enough, we can fit it in a multihash verbatim without having to 
+                // condense it using a hash function.
+                var alg = (ms.Length <= 48) ? "identity" : "sha2-256";
+
                 ms.Position = 0;
-                return MultiHash.ComputeHash(ms, "sha2-256");
+                return MultiHash.ComputeHash(ms, alg);
             }
         }
 

--- a/src/IpfsEngine.csproj
+++ b/src/IpfsEngine.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Makaretu.Dns.Unicast" Version="0.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
-    <PackageReference Include="PeerTalk" Version="0.10.0" />
+    <PackageReference Include="PeerTalk" Version="0.10.1" />
     <PackageReference Include="PeterO.Cbor" Version="3.1.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />

--- a/test/CoreApi/KeyApiTest.cs
+++ b/test/CoreApi/KeyApiTest.cs
@@ -363,6 +363,15 @@ IyIjAQyiOZZ5e8ozKAp5QFjQ/StM1uInn0v7Oi3vQRfbOOXcLXJL
         }
 
         [TestMethod]
+        public async Task Ed25519_Id_IdentityHash_of_PublicKey()
+        {
+            var name = "test-ed25519-id-hash";
+            var ipfs = TestFixture.Ipfs;
+            var key = await ipfs.Key.CreateAsync(name, "ed25519", 0);
+            Assert.AreEqual("identity", key.Id.Algorithm.Name);
+        }
+
+        [TestMethod]
         public async Task Import_OpenSSL_Ed25519()
         {
             // Created with:
@@ -377,7 +386,7 @@ MC4CAQAwBQYDK2VwBCIEIGJnyy3U4ksTQoRBz3mf1dxeFDPXZBrwh7gD7SqMg+/i
             await ipfs.Key.RemoveAsync("oed1");
             var key = await ipfs.Key.ImportAsync("oed1", pem);
             Assert.AreEqual("oed1", key.Name);
-            Assert.AreEqual("QmcYtMEm7n8cA8ZRtANgA7jGv8GSA4SS6ZEefZF9npLKZp", key.Id);
+            Assert.AreEqual("18n3naE9kBZoVvgYMV6saMZe3jn87dZiNbQ22BhxKTwU5yUoGfvBL1R3eScjokDGBk7i", key.Id);
 
             var keychain = await ipfs.KeyChain();
             var privateKey = await keychain.GetPrivateKeyAsync("oed1");


### PR DESCRIPTION
IPFS now uses the identity hash for a public ID that contains a public key <= 48 bytes.