### PR TITLE
Support core api 52

### DIFF
--- a/IpfsCli/Commands/BitswapCommand.cs
+++ b/IpfsCli/Commands/BitswapCommand.cs
@@ -11,6 +11,7 @@ namespace Ipfs.Cli
     [Subcommand("wantlist", typeof(BitswapWantListCommand))]
     [Subcommand("unwant", typeof(BitswapUnwantCommand))]
     [Subcommand("ledger", typeof(BitswapLedgerCommand))]
+    [Subcommand("stat", typeof(BitswapStatCommand))]
     class BitswapCommand : CommandBase
     {
         public Program Parent { get; set; }
@@ -75,4 +76,19 @@ namespace Ipfs.Cli
             return Program.Output(app, ledger, null);
         }
     }
+
+    [Command(Description = "Show bitswap information")]
+    class BitswapStatCommand : CommandBase
+    {
+        BitswapCommand Parent { get; set; }
+
+        protected override async Task<int> OnExecute(CommandLineApplication app)
+        {
+            var Program = Parent.Parent;
+
+            var stats = await Program.CoreApi.Stats.BitswapAsync();
+            return Program.Output(app, stats, null);
+        }
+    }
+
 }

--- a/IpfsCli/Commands/BitswapCommand.cs
+++ b/IpfsCli/Commands/BitswapCommand.cs
@@ -10,6 +10,7 @@ namespace Ipfs.Cli
     [Command(Description = "Manage swapped blocks")]
     [Subcommand("wantlist", typeof(BitswapWantListCommand))]
     [Subcommand("unwant", typeof(BitswapUnwantCommand))]
+    [Subcommand("ledger", typeof(BitswapLedgerCommand))]
     class BitswapCommand : CommandBase
     {
         public Program Parent { get; set; }
@@ -57,4 +58,21 @@ namespace Ipfs.Cli
         }
     }
 
+    [Command(Description = "Show the current ledger for a peer")]
+    class BitswapLedgerCommand : CommandBase
+    {
+        [Argument(0, "peerid", "The PeerID (B58) of the ledger to inspect")]
+        [Required]
+        public string PeerId { get; set; }
+
+        BitswapCommand Parent { get; set; }
+
+        protected override async Task<int> OnExecute(CommandLineApplication app)
+        {
+            var Program = Parent.Parent;
+            var peer = new Peer { Id = PeerId };
+            var ledger = await Program.CoreApi.Bitswap.LedgerAsync(peer);
+            return Program.Output(app, ledger, null);
+        }
+    }
 }

--- a/IpfsCli/IpfsCli.csproj
+++ b/IpfsCli/IpfsCli.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
-    <PackageReference Include="Ipfs.Http.Client" Version="0.29.0" />
+    <PackageReference Include="Ipfs.Http.Client" Version="0.30.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />

--- a/IpfsServer/HttpApi/V0/BitswapController.cs
+++ b/IpfsServer/HttpApi/V0/BitswapController.cs
@@ -36,6 +36,37 @@ namespace Ipfs.Server.HttpApi.V0
     }
 
     /// <summary>
+    ///   The bitswap ledger with another peer.
+    /// </summary>
+    public class BitswapLedgerDto
+    {
+        /// <summary>
+        ///   The peer ID.
+        /// </summary>
+        public string Peer;
+
+        /// <summary>
+        ///   The debt ratio.
+        /// </summary>
+        public double Value;
+
+        /// <summary>
+        ///   The number of bytes sent.
+        /// </summary>
+        public ulong Sent;
+
+        /// <summary>
+        ///   The number of bytes received.
+        /// </summary>
+        public ulong Recv;
+
+        /// <summary>
+        ///   The number blocks exchanged.
+        /// </summary>
+        public ulong Exchanged;
+    }
+
+    /// <summary>
     ///   Data trading module for IPFS. Its purpose is to request blocks from and 
     ///   send blocks to other peers in the network.
     /// </summary>
@@ -84,5 +115,25 @@ namespace Ipfs.Server.HttpApi.V0
             await IpfsCore.Bitswap.UnwantAsync(arg, Cancel);
         }
 
+        /// <summary>
+        ///   The blocks that are needed by a peer.
+        /// </summary>
+        /// <param name="arg">
+        ///   A peer ID or empty for self.
+        /// </param>
+        [HttpGet, HttpPost, Route("bitswap/ledger")]
+        public async Task<BitswapLedgerDto> Ledger(string arg)
+        {
+            var peer = new Peer { Id = arg };
+            var ledger = await IpfsCore.Bitswap.LedgerAsync(peer, Cancel);
+            return new BitswapLedgerDto
+            {
+                Peer = ledger.Peer.Id.ToBase58(),
+                Exchanged = ledger.BlocksExchanged,
+                Recv = ledger.DataReceived,
+                Sent = ledger.DataSent,
+                Value = ledger.DebtRatio
+            };
+        }
     }
 }

--- a/IpfsServer/HttpApi/V0/BitswapController.cs
+++ b/IpfsServer/HttpApi/V0/BitswapController.cs
@@ -119,7 +119,7 @@ namespace Ipfs.Server.HttpApi.V0
         ///   The blocks that are needed by a peer.
         /// </summary>
         /// <param name="arg">
-        ///   A peer ID or empty for self.
+        ///   A peer ID.
         /// </param>
         [HttpGet, HttpPost, Route("bitswap/ledger")]
         public async Task<BitswapLedgerDto> Ledger(string arg)

--- a/IpfsServer/HttpApi/V0/BitswapController.cs
+++ b/IpfsServer/HttpApi/V0/BitswapController.cs
@@ -135,5 +135,7 @@ namespace Ipfs.Server.HttpApi.V0
                 Value = ledger.DebtRatio
             };
         }
+
+        // "bitswap/stat" is handled by the StatsController.
     }
 }

--- a/IpfsServer/HttpApi/V0/StatsController.cs
+++ b/IpfsServer/HttpApi/V0/StatsController.cs
@@ -91,7 +91,7 @@ namespace Ipfs.Server.HttpApi.V0
         /// <summary>
         ///   Get bitswap information.
         /// </summary>
-        [HttpGet, HttpPost, Route("stats/bitswap")]
+        [HttpGet, HttpPost, Route("stats/bitswap"), Route("bitswap/stat")]
         public async Task<StatsBitswapDto> Bitswap()
         {
             Response.Headers.Add("X-Chunked-Output", "1");

--- a/IpfsServer/IpfsServer.csproj
+++ b/IpfsServer/IpfsServer.csproj
@@ -13,7 +13,7 @@
 
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ipfs.Core" Version="0.51.1" />
+    <PackageReference Include="Ipfs.Core" Version="0.52.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />

--- a/src/BlockExchange/Bitswap.cs
+++ b/src/BlockExchange/Bitswap.cs
@@ -22,7 +22,13 @@ namespace Ipfs.Engine.BlockExchange
         ConcurrentDictionary<Cid, WantedBlock> wants = new ConcurrentDictionary<Cid, WantedBlock>();
         ConcurrentDictionary<Peer, BitswapLedger> peerLedgers = new ConcurrentDictionary<Peer, BitswapLedger>();
 
-        IBitswapProtocol[] protocols;
+        /// <summary>
+        ///   The supported bitswap protocols.
+        /// </summary>
+        /// <value>
+        ///   Defaults to <see cref="Bitswap11"/> and <see cref="Bitswap1"/>.
+        /// </value>
+        public IBitswapProtocol[] Protocols;
 
         /// <summary>
         ///   The number of blocks sent by other peers.
@@ -67,7 +73,7 @@ namespace Ipfs.Engine.BlockExchange
         /// </summary>
         public Bitswap()
         {
-            protocols = new IBitswapProtocol[]
+            Protocols = new IBitswapProtocol[]
             {
                 new Bitswap11 { Bitswap = this },
                 new Bitswap1 { Bitswap = this }
@@ -140,7 +146,7 @@ namespace Ipfs.Engine.BlockExchange
         {
             log.Debug("Starting");
 
-            foreach (var protocol in protocols)
+            foreach (var protocol in Protocols)
             {
                 Swarm.AddProtocol(protocol);
             }
@@ -179,7 +185,7 @@ namespace Ipfs.Engine.BlockExchange
             log.Debug("Stopping");
 
             Swarm.ConnectionEstablished -= Swarm_ConnectionEstablished;
-            foreach (var protocol in protocols)
+            foreach (var protocol in Protocols)
             {
                 Swarm.RemoveProtocol(protocol);
             }
@@ -483,7 +489,7 @@ namespace Ipfs.Engine.BlockExchange
 
             // Send the want list to the peer on any bitswap protocol
             // that it supports.
-            foreach (var protocol in protocols)
+            foreach (var protocol in Protocols)
             {
                 try
                 {

--- a/src/BlockExchange/Bitswap1.cs
+++ b/src/BlockExchange/Bitswap1.cs
@@ -80,10 +80,7 @@ namespace Ipfs.Engine.BlockExchange
                 log.Debug("got some blocks");
                 foreach (var sentBlock in request.blocks)
                 {
-                    ++Bitswap.BlocksReceived;
-                    Bitswap.DataReceived += (ulong)sentBlock.Length;
-                    await Bitswap.BlockService.PutAsync(sentBlock, pin: false).ConfigureAwait(false);
-                    // TODO: Detect if duplicate and update stats
+                    await Bitswap.OnBlockReceivedAsync(connection.RemotePeer, sentBlock);
                 }
             }
         }
@@ -108,7 +105,7 @@ namespace Ipfs.Engine.BlockExchange
                 {
                     await SendAsync(stream, block, cancel).ConfigureAwait(false);
                 }
-
+                await Bitswap.OnBlockSentAsync(remotePeer, block);
             }
             catch (Exception e)
             {
@@ -152,8 +149,6 @@ namespace Ipfs.Engine.BlockExchange
             )
         {
             log.Debug($"Sending block {block.Id}");
-            ++Bitswap.BlocksSent;
-            Bitswap.DataSent += (ulong)block.Size;
 
             var message = new Message
             {

--- a/src/CoreApi/BitswapApi.cs
+++ b/src/CoreApi/BitswapApi.cs
@@ -23,6 +23,11 @@ namespace Ipfs.Engine.CoreApi
             return await bs.WantAsync(id, peer.Id, cancel).ConfigureAwait(false);
         }
 
+        public Task<BitswapLedger> LedgerAsync(Peer peer, CancellationToken cancel = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
         public async Task UnwantAsync(Cid id, CancellationToken cancel = default(CancellationToken))
         {
             (await ipfs.BitswapService.ConfigureAwait(false)).Unwant(id);

--- a/src/CoreApi/BitswapApi.cs
+++ b/src/CoreApi/BitswapApi.cs
@@ -23,9 +23,10 @@ namespace Ipfs.Engine.CoreApi
             return await bs.WantAsync(id, peer.Id, cancel).ConfigureAwait(false);
         }
 
-        public Task<BitswapLedger> LedgerAsync(Peer peer, CancellationToken cancel = default(CancellationToken))
+        public async Task<BitswapLedger> LedgerAsync(Peer peer, CancellationToken cancel = default(CancellationToken))
         {
-            throw new NotImplementedException();
+            var bs = await ipfs.BitswapService.ConfigureAwait(false);
+            return bs.PeerLedger(peer);
         }
 
         public async Task UnwantAsync(Cid id, CancellationToken cancel = default(CancellationToken))

--- a/src/CoreApi/BlockApi.cs
+++ b/src/CoreApi/BlockApi.cs
@@ -178,12 +178,17 @@ namespace Ipfs.Engine.CoreApi
                 };
             }
 
+            // CID V1 encoding defaulting to base32 which is not
+            // the multibase default. 
             var cid = new Cid
             {
                 ContentType = contentType,
-                Encoding = encoding,
                 Hash = MultiHash.ComputeHash(data, multiHash)
             };
+            if (encoding != "base58btc")
+            {
+                cid.Encoding = encoding;
+            }
             var block = new DataBlock
             {
                 DataBytes = data,

--- a/src/IpfsEngine.csproj
+++ b/src/IpfsEngine.csproj
@@ -50,11 +50,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ipfs.Core" Version="0.51.1" />
+    <PackageReference Include="Ipfs.Core" Version="0.52.1" />
     <PackageReference Include="Makaretu.Dns.Unicast" Version="0.10.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
-    <PackageReference Include="PeerTalk" Version="0.14.1" />
+    <PackageReference Include="PeerTalk" Version="0.14.2" />
     <PackageReference Include="PeterO.Cbor" Version="3.1.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />

--- a/test/CoreApi/BitswapApiTest.cs
+++ b/test/CoreApi/BitswapApiTest.cs
@@ -153,17 +153,17 @@ namespace Ipfs.Engine
                 var otherPeer = await ipfsOther.LocalPeer;
                 var ledger = await ipfs.Bitswap.LedgerAsync(otherPeer);
                 Assert.AreEqual(otherPeer, ledger.Peer);
-                Assert.AreEqual(1UL, ledger.BlocksExchanged);
-                Assert.AreEqual((ulong)block.Size, ledger.DataReceived);
+                Assert.AreNotEqual(0UL, ledger.BlocksExchanged);
+                Assert.AreNotEqual(0UL, ledger.DataReceived);
                 Assert.AreEqual(0UL, ledger.DataSent);
                 Assert.IsTrue(ledger.IsInDebt);
 
                 var localPeer = await ipfs.LocalPeer;
                 ledger = await ipfsOther.Bitswap.LedgerAsync(localPeer);
                 Assert.AreEqual(localPeer, ledger.Peer);
-                Assert.AreEqual(1UL, ledger.BlocksExchanged);
+                Assert.AreNotEqual(0UL, ledger.BlocksExchanged);
                 Assert.AreEqual(0UL, ledger.DataReceived);
-                Assert.AreEqual((ulong)block.Size, ledger.DataSent);
+                Assert.AreNotEqual(0UL, ledger.DataSent);
                 Assert.IsFalse(ledger.IsInDebt);
             }
             finally
@@ -218,17 +218,17 @@ namespace Ipfs.Engine
                 var otherPeer = await ipfsOther.LocalPeer;
                 var ledger = await ipfs.Bitswap.LedgerAsync(otherPeer);
                 Assert.AreEqual(otherPeer, ledger.Peer);
-                Assert.AreEqual(1UL, ledger.BlocksExchanged);
-                Assert.AreEqual((ulong)block.Size, ledger.DataReceived);
+                Assert.AreNotEqual(0UL, ledger.BlocksExchanged);
+                Assert.AreNotEqual(0UL, ledger.DataReceived);
                 Assert.AreEqual(0UL, ledger.DataSent);
                 Assert.IsTrue(ledger.IsInDebt);
 
                 var localPeer = await ipfs.LocalPeer;
                 ledger = await ipfsOther.Bitswap.LedgerAsync(localPeer);
                 Assert.AreEqual(localPeer, ledger.Peer);
-                Assert.AreEqual(1UL, ledger.BlocksExchanged);
+                Assert.AreNotEqual(0UL, ledger.BlocksExchanged);
                 Assert.AreEqual(0UL, ledger.DataReceived);
-                Assert.AreEqual((ulong)block.Size, ledger.DataSent);
+                Assert.AreNotEqual(0UL, ledger.DataSent);
                 Assert.IsFalse(ledger.IsInDebt);
             }
             finally
@@ -286,17 +286,17 @@ namespace Ipfs.Engine
                 var otherPeer = await ipfsOther.LocalPeer;
                 var ledger = await ipfs.Bitswap.LedgerAsync(otherPeer);
                 Assert.AreEqual(otherPeer, ledger.Peer);
-                Assert.AreEqual(1UL, ledger.BlocksExchanged);
-                Assert.AreEqual((ulong)block.Size, ledger.DataReceived);
+                Assert.AreNotEqual(0UL, ledger.BlocksExchanged);
+                Assert.AreNotEqual(0UL, ledger.DataReceived);
                 Assert.AreEqual(0UL, ledger.DataSent);
                 Assert.IsTrue(ledger.IsInDebt);
 
                 var localPeer = await ipfs.LocalPeer;
                 ledger = await ipfsOther.Bitswap.LedgerAsync(localPeer);
                 Assert.AreEqual(localPeer, ledger.Peer);
-                Assert.AreEqual(1UL, ledger.BlocksExchanged);
+                Assert.AreNotEqual(0UL, ledger.BlocksExchanged);
                 Assert.AreEqual(0UL, ledger.DataReceived);
-                Assert.AreEqual((ulong)block.Size, ledger.DataSent);
+                Assert.AreNotEqual(0UL, ledger.DataSent);
                 Assert.IsFalse(ledger.IsInDebt);
             }
             finally

--- a/test/CoreApi/BlockApiTest.cs
+++ b/test/CoreApi/BlockApiTest.cs
@@ -41,7 +41,7 @@ namespace Ipfs.Engine
         public void Put_Bytes_ContentType()
         {
             var cid = ipfs.Block.PutAsync(blob, contentType: "raw").Result;
-            Assert.AreEqual("zb2rhYDhWhxyHN6HFAKGvHnLogYfnk9KvzBUZvCg7sYhS22N8", (string)cid);
+            Assert.AreEqual("bafkreiaxnnnb7qz2focittuqq3ya25q7rcv3bqynnczfzako47346wosmu", (string)cid);
 
             var data = ipfs.Block.GetAsync(cid).Result;
             Assert.AreEqual(blob.Length, data.Size);
@@ -56,7 +56,7 @@ namespace Ipfs.Engine
                 ipfs.Options.Block.AllowInlineCid = true;
                 var cid = ipfs.Block.PutAsync(blob, contentType: "raw").Result;
                 Assert.IsTrue(cid.Hash.IsIdentityHash);
-                Assert.AreEqual("zz38RRn9SFSy", (string)cid);
+                Assert.AreEqual("bafkqablcnrxxeyq", (string)cid);
 
                 var data = ipfs.Block.GetAsync(cid).Result;
                 Assert.AreEqual(blob.Length, data.Size);
@@ -80,7 +80,7 @@ namespace Ipfs.Engine
         public void Put_Bytes_Hash()
         {
             var cid = ipfs.Block.PutAsync(blob, "raw", "sha2-512").Result;
-            Assert.AreEqual("zB7NCfbtX9WqFowgroqE19J841VESUhLc1enF7faMSMhTPMR4M3kWq7rS2AfCvdHeZ3RdfoSM45q7svoMQmw2NDD37z9F", (string)cid);
+            Assert.AreEqual("bafkrgqelljziv4qfg5mefz36m2y3h6voaralnw6lwb4f53xcnrf4mlsykkn7vt6eno547tw5ygcz62kxrle45wnbmpbofo5tvu57jvuaf7k7e", (string)cid);
 
             var data = ipfs.Block.GetAsync(cid).Result;
             Assert.AreEqual(blob.Length, data.Size);
@@ -116,7 +116,7 @@ namespace Ipfs.Engine
         public void Put_Stream_ContentType()
         {
             var cid = ipfs.Block.PutAsync(new MemoryStream(blob), contentType: "raw").Result;
-            Assert.AreEqual("zb2rhYDhWhxyHN6HFAKGvHnLogYfnk9KvzBUZvCg7sYhS22N8", (string)cid);
+            Assert.AreEqual("bafkreiaxnnnb7qz2focittuqq3ya25q7rcv3bqynnczfzako47346wosmu", (string)cid);
 
             var data = ipfs.Block.GetAsync(cid).Result;
             Assert.AreEqual(blob.Length, data.Size);
@@ -127,7 +127,7 @@ namespace Ipfs.Engine
         public void Put_Stream_Hash()
         {
             var cid = ipfs.Block.PutAsync(new MemoryStream(blob), "raw", "sha2-512").Result;
-            Assert.AreEqual("zB7NCfbtX9WqFowgroqE19J841VESUhLc1enF7faMSMhTPMR4M3kWq7rS2AfCvdHeZ3RdfoSM45q7svoMQmw2NDD37z9F", (string)cid);
+            Assert.AreEqual("bafkrgqelljziv4qfg5mefz36m2y3h6voaralnw6lwb4f53xcnrf4mlsykkn7vt6eno547tw5ygcz62kxrle45wnbmpbofo5tvu57jvuaf7k7e", (string)cid);
 
             var data = ipfs.Block.GetAsync(cid).Result;
             Assert.AreEqual(blob.Length, data.Size);

--- a/test/CoreApi/DagApiTest.cs
+++ b/test/CoreApi/DagApiTest.cs
@@ -19,7 +19,7 @@ namespace Ipfs.Engine
         public async Task Get_Raw()
         {
             var cid = await ipfs.Block.PutAsync(blob, contentType: "raw");
-            Assert.AreEqual("zb2rhYDhWhxyHN6HFAKGvHnLogYfnk9KvzBUZvCg7sYhS22N8", (string)cid);
+            Assert.AreEqual("bafkreiaxnnnb7qz2focittuqq3ya25q7rcv3bqynnczfzako47346wosmu", (string)cid);
 
             var dag = await ipfs.Dag.GetAsync(cid);
             Assert.AreEqual(blob64, (string) dag["data"]);
@@ -42,7 +42,7 @@ namespace Ipfs.Engine
         {
             var expected = new JObject();
             expected["a"] = "alpha";
-            var expectedId = "zdpuAyZWTqKMMn76eAAdDoL5nSdwZfSBRn5cSb2L4NALcWcyS";
+            var expectedId = "bafyreigdhej736dobd6z3jt2vxsxvbwrwgyts7e7wms6yrr46rp72uh5bu";
             var id = await ipfs.Dag.PutAsync(expected);
             Assert.IsNotNull(id);
             Assert.AreEqual(expectedId, (string)id);
@@ -110,7 +110,7 @@ namespace Ipfs.Engine
         {
             var data = Encoding.UTF8.GetBytes("abc");
             var id = await ipfs.Block.PutAsync(data, "raw");
-            Assert.AreEqual("zb2rhjCBERUodVMcKTiFjjbWP12nfh2nNKKcpDNHeQPReWC2G", id.Encode());
+            Assert.AreEqual("bafkreif2pall7dybz7vecqka3zo24irdwabwdi4wc55jznaq75q7eaavvu", id.Encode());
 
             var actual = await ipfs.Dag.GetAsync(id);
             Assert.AreEqual(Convert.ToBase64String(data), (string)actual["data"]);

--- a/test/CoreApi/FileSystemApiTest.cs
+++ b/test/CoreApi/FileSystemApiTest.cs
@@ -137,7 +137,7 @@ namespace Ipfs.Engine
                 RawLeaves = true
             };
             var node = await ipfs.FileSystem.AddTextAsync("hello world", options);
-            Assert.AreEqual("zCT5htkdzN4Q7EX2HUVByjuB7bgYszUosExP2iTMSLoSCsZDNHfm", (string)node.Id);
+            Assert.AreEqual("bafk2bzaceaswza5ss4iu2ia3galz6pyo6dfm5f4dmiw2lf2de22dmf4k533ba", (string)node.Id);
 
             var text = await ipfs.FileSystem.ReadAllTextAsync(node.Id);
             Assert.AreEqual("hello world", text);
@@ -263,7 +263,7 @@ namespace Ipfs.Engine
                 RawLeaves = true
             };
             var node = await ipfs.FileSystem.AddTextAsync("hello world", options);
-            Assert.AreEqual("zb2rhj7crUKTQYRGCRATFaQ6YFLTde2YzdqbbhAASkL9uRDXn", (string)node.Id);
+            Assert.AreEqual("bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", (string)node.Id);
             Assert.AreEqual(11, node.Size);
             Assert.AreEqual(0, node.Links.Count());
             Assert.AreEqual(false, node.IsDirectory);
@@ -287,7 +287,7 @@ namespace Ipfs.Engine
                 Assert.AreEqual(4, node.Size);
                 Assert.AreEqual(0, node.Links.Count());
                 Assert.AreEqual(false, node.IsDirectory);
-                Assert.AreEqual("zBJ95gnTvsVtx49wHb2LGj", node.Id.Encode());
+                Assert.AreEqual("bafyaadakbieaeeqenbuxsyiyaq", node.Id.Encode());
                 var text = await ipfs.FileSystem.ReadAllTextAsync(node.Id);
                 Assert.AreEqual("hiya", text);
             }
@@ -311,10 +311,10 @@ namespace Ipfs.Engine
             Assert.AreEqual("QmUuooB6zEhMmMaBvMhsMaUzar5gs5KwtVSFqG4C1Qhyhs", (string)node.Id);
             Assert.AreEqual(false, node.IsDirectory);
             Assert.AreEqual(4, links.Length);
-            Assert.AreEqual("zb2rhm6D8PTYoMh7PSFKbCxxcD1yjWPD5KPr6nVRuw9ymDyUL", (string)links[0].Id);
-            Assert.AreEqual("zb2rhgo7y6J7p76kCrXs4pmmMQx56fZeWJkC3sfbjeay4UruU", (string)links[1].Id);
-            Assert.AreEqual("zb2rha4Pd2AruByr2RwzhRCVxRCqBC67h7ukTJd99jCjUtmyM", (string)links[2].Id);
-            Assert.AreEqual("zb2rhn6eZLLj7vdVizbNxpASGoVw4vcSmc8avHXmDMVu5ZA6Q", (string)links[3].Id);
+            Assert.AreEqual("bafkreigwvapses57f56cfow5xvoua4yowigpwcz5otqqzk3bpcbbjswowe", (string)links[0].Id);
+            Assert.AreEqual("bafkreiew3cvfrp2ijn4qokcp5fqtoknnmr6azhzxovn6b3ruguhoubkm54", (string)links[1].Id);
+            Assert.AreEqual("bafkreibsybcn72tquh2l5zpim2bba4d2kfwcbpzuspdyv2breaq5efo7tq", (string)links[2].Id);
+            Assert.AreEqual("bafkreihfuch72plvbhdg46lef3n5zwhnrcjgtjywjryyv7ffieyedccchu", (string)links[3].Id);
 
             var text = await ipfs.FileSystem.ReadAllTextAsync(node.Id);
             Assert.AreEqual("hello world", text);


### PR DESCRIPTION
- BREAKING CHANGE: when the CID is V1 then use "base32" as the default encoding. For CID V0 it is still "base58btc"
- BitswapApi.LedgerAsync