### PR TITLE
Unixfs balanced trees

### DIFF
--- a/IpfsCli/Program.cs
+++ b/IpfsCli/Program.cs
@@ -90,7 +90,7 @@ namespace Ipfs.Cli
             }
 
             var took = DateTime.Now - startTime;
-            Console.Write($"Took {took.TotalSeconds} seconds.");
+            //Console.Write($"Took {took.TotalSeconds} seconds.");
 
             return 0;
         }

--- a/src/CoreApi/FileSystemApi.cs
+++ b/src/CoreApi/FileSystemApi.cs
@@ -99,7 +99,7 @@ namespace Ipfs.Engine.CoreApi
                 return nodes.First();
             }
 
-            // Bundle X links into a block.
+            // Bundle DefaultLinksPerBlock links into a block.
             var tree = new List<FileSystemNode>();
             for (int i = 0; true; ++i)
             {
@@ -126,6 +126,7 @@ namespace Ipfs.Engine.CoreApi
             // Build the DAG that contains all the file nodes.
             var links = nodes.Select(n => n.ToLink()).ToArray();
             var fileSize = (ulong)nodes.Sum(n => n.Size);
+            var dagSize = nodes.Sum(n => n.DagSize);
             var dm = new DataMessage
             {
                 Type = DataType.File,
@@ -148,7 +149,7 @@ namespace Ipfs.Engine.CoreApi
             {
                 Id = dag.Id,
                 Size = (long)dm.FileSize,
-                DagSize = dag.Size,
+                DagSize = dagSize + dag.Size,
                 Links = links
             };
         }

--- a/src/UnixFileSystem/DataMessage.cs
+++ b/src/UnixFileSystem/DataMessage.cs
@@ -10,13 +10,39 @@ using System.Threading.Tasks;
 
 namespace Ipfs.Engine.UnixFileSystem
 {
-    enum DataType
+    /// <summary>
+    ///   Specifies the type of data.
+    /// </summary>
+    public enum DataType
     {
+        /// <summary>
+        ///  Raw data
+        /// </summary>
         Raw = 0,
+
+        /// <summary>
+        ///   A directory of files. 
+        /// </summary>
         Directory = 1,
+
+        /// <summary>
+        ///   A file.
+        /// </summary>
         File = 2,
+
+        /// <summary>
+        ///  Metadata (NYI) 
+        /// </summary>
         Metadata = 3,
+
+        /// <summary>
+        ///  Symbolic link (NYI) 
+        /// </summary>
         Symlink = 4,
+
+        /// <summary>
+        ///  NYI 
+        /// </summary>
         HAMTShard = 5
     };
 
@@ -24,25 +50,43 @@ namespace Ipfs.Engine.UnixFileSystem
     ///   The ProtoBuf data that is stored in a DAG.
     /// </summary>
     [ProtoContract]
-    internal class DataMessage
+    public class DataMessage
     {
+        /// <summary>
+        ///   The type of data.
+        /// </summary>
         [ProtoMember(1, IsRequired = true)]
         public DataType Type;
 
+        /// <summary>
+        ///   The data.
+        /// </summary>
         [ProtoMember(2, IsRequired = false)]
         public byte[] Data;
 
+        /// <summary>
+        ///   The file size.
+        /// </summary>
         [ProtoMember(3, IsRequired = false)]
         public ulong? FileSize;
 
+        /// <summary>
+        ///  The file size of each block.
+        /// </summary>
         [ProtoMember(4, IsRequired = false)]
         public ulong[] BlockSizes;
 
 #pragma warning disable 0649 // disable warning about unassinged fields
+        /// <summary>
+        ///   NYI
+        /// </summary>
         [ProtoMember(5, IsRequired = false)]
         public ulong? HashType;
 
 #pragma warning disable 0649 // disable warning about unassinged fields
+        /// <summary>
+        ///   NYI
+        /// </summary>
         [ProtoMember(6, IsRequired = false)]
         public ulong? Fanout;
     }

--- a/src/UnixFileSystem/FileSystem.cs
+++ b/src/UnixFileSystem/FileSystem.cs
@@ -16,7 +16,7 @@ namespace Ipfs.Engine.UnixFileSystem
     /// </summary>
     public static class FileSystem
     {
-        static byte[] emptyData = new byte[0];
+        static readonly byte[] emptyData = new byte[0];
 
         /// <summary>
         ///   Creates a stream that can read the supplied <see cref="Cid"/>.

--- a/src/UnixFileSystem/SizeChunker.cs
+++ b/src/UnixFileSystem/SizeChunker.cs
@@ -40,7 +40,7 @@ namespace Ipfs.Engine.UnixFileSystem
         ///    A task that represents the asynchronous operation. The task's value is
         ///    the sequence of file system nodes of the added data blocks.
         /// </returns>
-        public async Task<IEnumerable<FileSystemNode>> ChunkAsync(
+        public async Task<List<FileSystemNode>> ChunkAsync(
             Stream stream, 
             string name,
             AddFileOptions options, 

--- a/test/IpfsEngineTests.csproj
+++ b/test/IpfsEngineTests.csproj
@@ -33,6 +33,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="starx2.mp4">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="star_trails.mp4">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Very large files are split into multiple nodes; not just one node linking to all blocks.  IPFS uses 174 blocks per node.  Issue #125