### PR TITLE
ObjectApi.LinksAsync

### DIFF
--- a/src/CoreApi/ObjectApi.cs
+++ b/src/CoreApi/ObjectApi.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -49,8 +50,16 @@ namespace Ipfs.Engine.CoreApi
 
         public async Task<IEnumerable<IMerkleLink>> LinksAsync(Cid id, CancellationToken cancel = default(CancellationToken))
         {
-            var node = await GetAsync(id, cancel).ConfigureAwait(false);
-            return node.Links;
+            var block = await ipfs.Block.GetAsync(id, cancel).ConfigureAwait(false);
+            try
+            {
+                var node = new DagNode(block.DataStream);
+                return node.Links;
+            }
+            catch
+            {
+                return Enumerable.Empty<IMerkleLink>();
+            }
         }
 
         public Task<DagNode> NewAsync(string template = null, CancellationToken cancel = default(CancellationToken))

--- a/test/CoreApi/ObjectApiTest.cs
+++ b/test/CoreApi/ObjectApiTest.cs
@@ -158,5 +158,35 @@ namespace Ipfs.Engine.CoreApi
             }
         }
 
+        [TestMethod]
+        public async Task Links_InlineCid()
+        {
+            var original = ipfs.Options.Block.AllowInlineCid;
+            try
+            {
+                ipfs.Options.Block.AllowInlineCid = true;
+
+                var node = await ipfs.FileSystem.AddTextAsync("hiya");
+                Assert.AreEqual(1, node.Id.Version);
+                Assert.IsTrue(node.Id.Hash.IsIdentityHash);
+
+                var links = await ipfs.Object.LinksAsync(node.Id);
+                Assert.AreEqual(0, links.Count());
+            }
+            finally
+            {
+                ipfs.Options.Block.AllowInlineCid = original;
+            }
+        }
+
+        [TestMethod]
+        public async Task Links_RawCid()
+        {
+            var blob = new byte[2048];
+            var cid = await ipfs.Block.PutAsync(blob, contentType: "raw");
+
+            var links = await ipfs.Object.LinksAsync(cid);
+            Assert.AreEqual(0, links.Count());
+        }
     }
 }


### PR DESCRIPTION
Return empty is unreadable.  Fixes #135 