### PR TITLE
Send cancels to peers

### DIFF
--- a/src/BlockExchange/Bitswap1.cs
+++ b/src/BlockExchange/Bitswap1.cs
@@ -117,24 +117,27 @@ namespace Ipfs.Engine.BlockExchange
         /// <inheritdoc />
         public async Task SendWantsAsync(
             Stream stream,
-            IEnumerable<WantedBlock> wants,
+            IEnumerable<Cid> wants,
+            IEnumerable<Cid> cancels,
             bool full = true,
             CancellationToken cancel = default(CancellationToken)
             )
         {
-            log.Debug("Sending want list");
-
+            var entries = new List<Entry>();
+            foreach (var cid in wants)
+            {
+                entries.Add(new Entry { block = cid.ToArray() });
+            }
+            foreach (var cid in cancels)
+            {
+                entries.Add(new Entry { block = cid.ToArray(), cancel = true });
+            }
             var message = new Message
             {
                 wantlist = new Wantlist
                 {
                     full = full,
-                    entries = wants
-                        .Select(w => new Entry
-                        {
-                            block = w.Id.Hash.ToArray()
-                        })
-                        .ToArray()
+                    entries = entries.ToArray(),
                 }
             };
 

--- a/src/BlockExchange/Bitswap1.cs
+++ b/src/BlockExchange/Bitswap1.cs
@@ -61,8 +61,7 @@ namespace Ipfs.Engine.BlockExchange
                     Cid cid = s;
                     if (entry.cancel)
                     {
-                        // TODO: Unwant specific to remote peer
-                        Bitswap.Unwant(cid);
+                        Bitswap.Unwant(cid, connection.RemotePeer.Id);
                     }
                     else
                     {

--- a/src/BlockExchange/Bitswap11.cs
+++ b/src/BlockExchange/Bitswap11.cs
@@ -57,10 +57,10 @@ namespace Ipfs.Engine.BlockExchange
                     foreach (var entry in request.wantlist.entries)
                     {
                         var cid = Cid.Read(entry.block);
+                        log.Debug($"entry {cid} cancel {entry.cancel}");
                         if (entry.cancel)
                         {
-                            // TODO: Unwant specific to remote peer
-                            Bitswap.Unwant(cid);
+                            Bitswap.Unwant(cid, connection.RemotePeer.Id);
                         }
                         else
                         {

--- a/src/BlockExchange/Bitswap11.cs
+++ b/src/BlockExchange/Bitswap11.cs
@@ -126,24 +126,27 @@ namespace Ipfs.Engine.BlockExchange
         /// <inheritdoc />
         public async Task SendWantsAsync(
             Stream stream,
-            IEnumerable<WantedBlock> wants,
+            IEnumerable<Cid> wants,
+            IEnumerable<Cid> cancels,
             bool full = true,
             CancellationToken cancel = default(CancellationToken)
             )
         {
+            var entries = new List<Entry>();
+            foreach (var cid in wants)
+            {
+                entries.Add(new Entry { block = cid.ToArray() });
+            }
+            foreach (var cid in cancels)
+            {
+                entries.Add(new Entry { block = cid.ToArray(), cancel = true });
+            }
             var message = new Message
             {
                 wantlist = new Wantlist
                 {
                     full = full,
-                    entries = wants
-                        .Select(w => {
-                            return new Entry
-                            {
-                                block = w.Id.ToArray()
-                            };
-                         })
-                        .ToArray()
+                    entries = entries.ToArray(),
                 },
                 payload = new List<Block>(0)
             };

--- a/src/BlockExchange/IBitswapProtocol.cs
+++ b/src/BlockExchange/IBitswapProtocol.cs
@@ -21,7 +21,10 @@ namespace Ipfs.Engine.BlockExchange
         ///   The destination of the want list.
         /// </param>
         /// <param name="wants">
-        ///   A sequence of <see cref="WantedBlock"/>.
+        ///   A sequence of <see cref="Cid"/> that is wanted.
+        /// </param>
+        /// <param name="cancels">
+        ///   A sequence of <see cref="Cid"/> that is not wanted.
         /// </param>
         /// <param name="full">
         ///   <b>true</b> if <paramref name="wants"/> is the full want list.
@@ -35,7 +38,8 @@ namespace Ipfs.Engine.BlockExchange
         Task SendWantsAsync
         (
             Stream stream,
-            IEnumerable<WantedBlock> wants,
+            IEnumerable<Cid> wants,
+            IEnumerable<Cid> cancels,
             bool full = true,
             CancellationToken cancel = default(CancellationToken)
         );

--- a/src/BlockExchange/WantedBlock.cs
+++ b/src/BlockExchange/WantedBlock.cs
@@ -16,19 +16,18 @@ namespace Ipfs.Engine.BlockExchange
     public class WantedBlock
     {
         /// <summary>
-        ///   The content ID of the block;
+        ///   The content ID of the block.
         /// </summary>
         public Cid Id;
 
         /// <summary>
-        ///   The peers that want the block.
-        /// </summary>
-        public List<MultiHash> Peers;
-
-        /// <summary>
         ///   The consumers that are waiting for the block.
         /// </summary>
-        public List<TaskCompletionSource<IDataBlock>> Consumers;
+        /// <remarks>
+        ///   The keys is a TaskCompletionSource and the value is
+        ///   the peer ID.
+        /// </remarks>
+        public ConcurrentDictionary<TaskCompletionSource<IDataBlock>, MultiHash> Tasks;
     }
 
 }

--- a/src/IpfsEngine.csproj
+++ b/src/IpfsEngine.csproj
@@ -54,7 +54,7 @@
     <PackageReference Include="Makaretu.Dns.Unicast" Version="0.11.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
-    <PackageReference Include="PeerTalk" Version="0.20.1" />
+    <PackageReference Include="PeerTalk" Version="0.20.2" />
     <PackageReference Include="PeterO.Cbor" Version="3.1.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />

--- a/test/BlockExchange/BitswapTest .cs
+++ b/test/BlockExchange/BitswapTest .cs
@@ -17,6 +17,11 @@ namespace Ipfs.Engine.BlockExchange
             Id = "QmXK9VBxaXFuuT29AaPUTgW3jBWZ9JgLVZYdMYTHC6LLAH",
             PublicKey = "CAASXjBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCC5r4nQBtnd9qgjnG8fBN5+gnqIeWEIcUFUdCG4su/vrbQ1py8XGKNUBuDjkyTv25Gd3hlrtNJV3eOKZVSL8ePAgMBAAE="
         };
+        Peer other = new Peer
+        {
+            Id = "QmXK9VBxaXFuuT29AaPUTgW3jBWZ9JgLVZYdMYTHC6LLAX",
+            PublicKey = "CAASXjBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCC5r4nQBtnd9qgjnG8fBN5+gnqIeWEIcUFUdCG4su/vrbQ1py8XGKNUBuDjkyTv25Gd3hlrtNJV3eOKZVSL8ePAgMBAAE="
+        };
 
         [TestMethod]
         public void WantList()
@@ -86,6 +91,28 @@ namespace Ipfs.Engine.BlockExchange
             bitswap.Unwant(cid);
             Assert.IsTrue(task.IsCanceled);
             CollectionAssert.DoesNotContain(bitswap.PeerWants(self.Id).ToArray(), cid);
+        }
+
+        [TestMethod]
+        public void Want_Unwant_PeerSpecific()
+        {
+            var bitswap = new Bitswap { Swarm = new Swarm { LocalPeer = self } };
+            var cid = new DagNode(Encoding.UTF8.GetBytes("Want_Unwant_PeerSpecific unknown block")).Id;
+            var cts = new CancellationTokenSource();
+            var task1 = bitswap.WantAsync(cid, self.Id, cts.Token);
+            var cts2 = new CancellationTokenSource();
+            var task2 = bitswap.WantAsync(cid, other.Id, cts.Token);
+
+            CollectionAssert.Contains(bitswap.PeerWants(self.Id).ToArray(), cid);
+            CollectionAssert.Contains(bitswap.PeerWants(other.Id).ToArray(), cid);
+
+            bitswap.Unwant(cid, self.Id);
+            CollectionAssert.DoesNotContain(bitswap.PeerWants(self.Id).ToArray(), cid);
+            CollectionAssert.Contains(bitswap.PeerWants(other.Id).ToArray(), cid);
+
+            bitswap.Unwant(cid, other.Id);
+            CollectionAssert.DoesNotContain(bitswap.PeerWants(self.Id).ToArray(), cid);
+            CollectionAssert.DoesNotContain(bitswap.PeerWants(other.Id).ToArray(), cid);
         }
 
         [TestMethod]

--- a/test/CoreApi/BitswapApiTest.cs
+++ b/test/CoreApi/BitswapApiTest.cs
@@ -1,6 +1,7 @@
 ﻿using Ipfs.Engine.BlockExchange;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -111,6 +112,110 @@ namespace Ipfs.Engine
                 }
 
                 Assert.Fail("want list not sent");
+            }
+            finally
+            {
+                await ipfsOther.StopAsync();
+                await ipfs.StopAsync();
+
+                ipfs.Options.Discovery = new DiscoveryOptions();
+                ipfsOther.Options.Discovery = new DiscoveryOptions();
+            }
+        }
+
+        [TestMethod]
+        public async Task Sends_Cancel_on_Unwant()
+        {
+            ipfs.Options.Discovery.DisableMdns = true;
+            ipfs.Options.Discovery.BootstrapPeers = new MultiAddress[0];
+            await ipfs.StartAsync();
+
+            ipfsOther.Options.Discovery.DisableMdns = true;
+            ipfsOther.Options.Discovery.BootstrapPeers = new MultiAddress[0];
+            await ipfsOther.StartAsync();
+            try
+            {
+                var local = await ipfs.LocalPeer;
+                var remote = await ipfsOther.LocalPeer;
+
+                var data = Guid.NewGuid().ToByteArray();
+                var cid = new Cid { Hash = MultiHash.ComputeHash(data) };
+                var cts = new CancellationTokenSource();
+                var _ = ipfs.Block.GetAsync(cid, cts.Token);
+                await ipfs.Swarm.ConnectAsync(remote.Addresses.First());
+
+                // Send the want list.
+                var endTime = DateTime.Now.AddSeconds(10);
+                IEnumerable<Cid> wants = null;
+                while (DateTime.Now < endTime && (wants == null || !wants.Contains(cid)))
+                {
+                    wants = await ipfsOther.Bitswap.WantsAsync(local.Id);
+                    await Task.Delay(200);
+                }
+                Assert.IsTrue(wants != null && wants.Contains(cid), "want list not sent");
+
+                // Send the cancel list.
+                cts.Cancel();
+                endTime = DateTime.Now.AddSeconds(10);
+                wants = null;
+                while (DateTime.Now < endTime && (wants == null || wants.Contains(cid)))
+                {
+                    wants = await ipfsOther.Bitswap.WantsAsync(local.Id);
+                    await Task.Delay(200);
+                }
+                Assert.IsTrue(wants != null && !wants.Contains(cid), "cancel list not sent");
+            }
+            finally
+            {
+                await ipfsOther.StopAsync();
+                await ipfs.StopAsync();
+
+                ipfs.Options.Discovery = new DiscoveryOptions();
+                ipfsOther.Options.Discovery = new DiscoveryOptions();
+            }
+        }
+
+        [TestMethod]
+        public async Task Sends_Cancel_on_Found()
+        {
+            ipfs.Options.Discovery.DisableMdns = true;
+            ipfs.Options.Discovery.BootstrapPeers = new MultiAddress[0];
+            await ipfs.StartAsync();
+
+            ipfsOther.Options.Discovery.DisableMdns = true;
+            ipfsOther.Options.Discovery.BootstrapPeers = new MultiAddress[0];
+            await ipfsOther.StartAsync();
+            try
+            {
+                var local = await ipfs.LocalPeer;
+                var remote = await ipfsOther.LocalPeer;
+
+                var data = Guid.NewGuid().ToByteArray();
+                var cid = new Cid { Hash = MultiHash.ComputeHash(data) };
+                var cts = new CancellationTokenSource();
+                var _ = ipfs.Block.GetAsync(cid, cts.Token);
+                await ipfs.Swarm.ConnectAsync(remote.Addresses.First());
+
+                // Send the want list.
+                var endTime = DateTime.Now.AddSeconds(10);
+                IEnumerable<Cid> wants = null;
+                while (DateTime.Now < endTime && (wants == null || !wants.Contains(cid)))
+                {
+                    wants = await ipfsOther.Bitswap.WantsAsync(local.Id);
+                    await Task.Delay(200);
+                }
+                Assert.IsTrue(wants != null && wants.Contains(cid), "want list not sent");
+
+                // Send the cancel list.
+                await ipfs.Block.PutAsync(data);
+                endTime = DateTime.Now.AddSeconds(10);
+                wants = null;
+                while (DateTime.Now < endTime && (wants == null || wants.Contains(cid)))
+                {
+                    wants = await ipfsOther.Bitswap.WantsAsync(local.Id);
+                    await Task.Delay(200);
+                }
+                Assert.IsTrue(wants != null && !wants.Contains(cid), "cancel list not sent");
             }
             finally
             {

--- a/test/CoreApi/FileSystemApiTest.cs
+++ b/test/CoreApi/FileSystemApiTest.cs
@@ -796,6 +796,7 @@ namespace Ipfs.Engine
 
                 // Start bootstrap node.
                 b.Options.Discovery.DisableMdns = true;
+                b.Options.Discovery.DisableRandomWalk = true;
                 b.Options.Swarm.MinConnections = 0;
                 b.Options.Swarm.PrivateNetworkKey = psk;
                 b.Options.Discovery.BootstrapPeers = new MultiAddress[0];
@@ -808,6 +809,7 @@ namespace Ipfs.Engine
 
                 // Node that has the content.
                 c.Options.Discovery.DisableMdns = true;
+                c.Options.Discovery.DisableRandomWalk = true;
                 c.Options.Swarm.MinConnections = 0;
                 c.Options.Swarm.PrivateNetworkKey = psk;
                 c.Options.Discovery.BootstrapPeers = bootstrapPeers;
@@ -820,10 +822,12 @@ namespace Ipfs.Engine
 
                 // Node that reads the content.
                 a.Options.Discovery.DisableMdns = true;
+                a.Options.Discovery.DisableRandomWalk = true;
                 a.Options.Swarm.MinConnections = 0;
                 a.Options.Swarm.PrivateNetworkKey = psk;
                 a.Options.Discovery.BootstrapPeers = bootstrapPeers;
                 await a.StartAsync();
+                await a.Swarm.ConnectAsync(bootstrapPeers[0]);
                 Console.WriteLine($"A is {await a.LocalPeer}");
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 var content = await a.FileSystem.ReadAllTextAsync(cid, cts.Token);

--- a/test/CoreApi/FileSystemApiTest.cs
+++ b/test/CoreApi/FileSystemApiTest.cs
@@ -796,8 +796,6 @@ namespace Ipfs.Engine
 
                 // Start bootstrap node.
                 b.Options.Discovery.DisableMdns = true;
-                b.Options.Discovery.DisableRandomWalk = true;
-                b.Options.Swarm.MinConnections = 0;
                 b.Options.Swarm.PrivateNetworkKey = psk;
                 b.Options.Discovery.BootstrapPeers = new MultiAddress[0];
                 await b.StartAsync();
@@ -809,8 +807,6 @@ namespace Ipfs.Engine
 
                 // Node that has the content.
                 c.Options.Discovery.DisableMdns = true;
-                c.Options.Discovery.DisableRandomWalk = true;
-                c.Options.Swarm.MinConnections = 0;
                 c.Options.Swarm.PrivateNetworkKey = psk;
                 c.Options.Discovery.BootstrapPeers = bootstrapPeers;
                 await c.StartAsync();
@@ -822,8 +818,6 @@ namespace Ipfs.Engine
 
                 // Node that reads the content.
                 a.Options.Discovery.DisableMdns = true;
-                a.Options.Discovery.DisableRandomWalk = true;
-                a.Options.Swarm.MinConnections = 0;
                 a.Options.Swarm.PrivateNetworkKey = psk;
                 a.Options.Discovery.BootstrapPeers = bootstrapPeers;
                 await a.StartAsync();


### PR DESCRIPTION
When a wanted block is found or cancelled, then a cancel message should be sent to other peers; see #147